### PR TITLE
Fix for incorrect PArrived results

### DIFF
--- a/examples/Basic/CMakeLists.txt
+++ b/examples/Basic/CMakeLists.txt
@@ -18,6 +18,9 @@ list(APPEND mpipcl_test_execs MPIPCL_Test_5)
 add_executable(MPIPCL_Test_6 mpipcltest6.c)
 list(APPEND mpipcl_test_execs MPIPCL_Test_6)
 
+add_executable(MPIPCL_Test_7 mpipcltest7.c)
+list(APPEND mpipcl_test_execs MPIPCL_Test_7)
+
 foreach(exec_target ${mpipcl_test_execs})
 	if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
 		target_compile_options(${exec_target} PRIVATE -Wall -Wextra -Wpedantic)

--- a/examples/Basic/mpipcltest7.c
+++ b/examples/Basic/mpipcltest7.c
@@ -1,0 +1,99 @@
+/* Sample program to test the partitioned communication API,
+ * specifically the use of parrived "to make progress." This
+ * program is also testing out that the mapping of "user
+ * partitions" can correctly be mapped to "network partitions"
+ * by making the receive side request double the number of partitions
+ * as the send side needs. 
+ *
+ * To run:
+ *    mpirun -np 2 ./<exec> <npartitions> <bufsize>
+ *    NOTE: bufsize % npartitions == 0 and
+ *          bufsize % (npartitions * 2) == 0
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <mpi.h>
+#include "mpipcl.h"
+
+int main(int argc, char *argv[]) {
+  int rank, size, nparts, bufsize, count, tag = 0xbad;
+  int i, j, provided;
+  double *buf, sum;
+  MPIX_Request req;
+  MPI_Status status;
+
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
+  assert(provided == MPI_THREAD_SERIALIZED);
+  
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  assert(size == 2);
+
+  if (argc != 3) {
+    printf("Usage: %s <#partitions> <bufsize>\n", argv[0]);
+    MPI_Abort(MPI_COMM_WORLD, -1);
+  }
+
+  nparts = atoi(argv[1]);
+  bufsize = atoi(argv[2]);
+  count = bufsize/nparts;
+  
+  if ((size != 2) || (bufsize % nparts != 0)) {
+    printf("comm size must be 2 and bufsize must be divisible by nparts\n");
+    MPI_Abort(MPI_COMM_WORLD, -1);
+  }
+
+  if(bufsize % (2*nparts) != 0) {
+    printf("bufsize must also be divisible by twice nparts\n");
+    MPI_Abort(MPI_COMM_WORLD, -2);
+  }
+  
+  buf = malloc(sizeof(double) * bufsize);
+
+  if (rank == 0) { /* sender */
+    MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD, MPI_INFO_NULL, &req);
+    MPIX_Start(&req);
+
+    for (i = 0; i < nparts; i++) {
+       /* initialize part of buffer in each thread */
+       for (j = 0; j < count; j++) 
+          buf[j + i*count] = j + i*count + 1.0;
+
+       /* indicate buffer is ready */
+       MPIX_Pready(i, &req);
+    }
+
+    MPIX_Wait(&req, &status);
+
+  } else {         /* receiver */
+    nparts *= 2;
+    count   = count/2;
+    MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD, MPI_INFO_NULL, &req);
+    MPIX_Start(&req);
+
+    for (i = 0; i < nparts; i++) {
+       int done = 0;
+       while(!done)
+       {
+        MPIX_Parrived(&req, i, &done);
+       }
+        printf("Done with partition %d\n", i);
+    }
+
+    MPIX_Wait(&req, &status);
+
+    /* compute the sum of the values received */
+    for (i = 0, sum = 0.0; i < bufsize; i++)
+       sum += buf[i];
+
+    printf("#partitions = %d bufsize = %d count = %d sum = %f\n", 
+           nparts, bufsize, count, sum);
+  }
+
+  MPIX_Request_free(&req);
+  free(buf);
+  MPI_Finalize();
+
+  return 0;
+}

--- a/include/mpipcl.h
+++ b/include/mpipcl.h
@@ -106,7 +106,7 @@ int MPIX_Request_free(MPIX_Request *request);
 
 // functions current defined outside of mpipcl
 // setup.c
-void prep(void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int opp, int tag, MPI_Info info, MPI_Comm comm, MPIX_Request *request);
+void prep(void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int opp, int tag, MPI_Comm comm, MPIX_Request *request);
 int sync_driver(MPI_Info info, MPIX_Request *request);
 void internal_setup(MPIX_Request *request);
 void reset_status(MPIX_Request *request);
@@ -122,9 +122,6 @@ void send_ready(MPIX_Request *request);
 void general_send(int id, MPIX_Request *request);
 
 // remap functions
-void map_send_buffer_percent(int id, MPIX_Request *request);
-void map_send_buffer_bool(int id, MPIX_Request *request);
-void map_send_buffer_count(int id, MPIX_Request *request);
 int map_recv_buffer(int id, MPIX_Request *request);
 
 // debug functions

--- a/src/pt2pt/mpipcl.c
+++ b/src/pt2pt/mpipcl.c
@@ -7,7 +7,7 @@ int MPIX_Psend_init(void *buf, int partitions, MPI_Count count,
                     MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPIX_Request *request)
 {
   request->side = SENDER;
-  prep(buf, partitions, count, datatype, dest, tag, info, comm, request);
+  prep(buf, partitions, count, datatype, dest, tag, comm, request);
   sync_driver(info, request);
 
   return MPI_SUCCESS;
@@ -18,7 +18,7 @@ int MPIX_Precv_init(void *buf, int partitions, MPI_Count count,
                     MPIX_Request *request)
 {
   request->side = RECEIVER;
-  prep(buf, partitions, count, datatype, dest, tag, info, comm, request);
+  prep(buf, partitions, count, datatype, dest, tag, comm, request);
   sync_driver(info, request);
 
   return MPI_SUCCESS;

--- a/src/pt2pt/send.c
+++ b/src/pt2pt/send.c
@@ -1,5 +1,7 @@
 #include "mpipcl.h"
 
+#include <math.h>
+
 // call send function on all marked partitions
 // catchup function for sync thread.
 void send_ready(MPIX_Request *request)
@@ -14,120 +16,42 @@ void send_ready(MPIX_Request *request)
 	}
 }
 
+static inline void map_local_partition(int user_partition_id, MPIX_Request* request, int* start, int* end)
+{
+	int user_partitions = request->local_parts;
+	int network_partitions = request->parts;
+
+	// MPIPCL_DEBUG("User %d Network %d \n",user_partitions, network_partitions);
+
+	int temp_start = (network_partitions / user_partitions) * user_partition_id;
+	int temp_end   = ceil(network_partitions / user_partitions) * user_partition_id+1;
+
+	MPIPCL_DEBUG("Start %d End %d \n",temp_start, temp_end);
+	assert(temp_start >= 0 && temp_end > temp_start && temp_end <= network_partitions);
+
+	*start = temp_start;
+	*end   = temp_end;
+}
+
 // given partition id, send now ready internal requests.
 void general_send(int id, MPIX_Request *request)
 {
-	// pthread_mutex_lock(&request->lock);
-
-	// update status of internal requests.
-	map_send_buffer_count(id, request);
-
-	// pthread_mutex_unlock(&request->lock);
-}
-
-// maps send_buffer offsets - advice on locking mechanism needed.
-// Use percentile filling to determine
-// Pros: does not have to check status external partitions
-// Cons: Due to rounding error only works on up to 256ish parts.
-void map_send_buffer_percent(int id, MPIX_Request *request)
-{
-	int start_element = id * request->local_size;
-	int current_part = start_element / request->size;
-	int end_part = (start_element + request->local_size - 1) / request->size;
-
-	int start_offset = current_part * request->size; // first element of first i request.
-	int remaining = request->local_size;
-
-	int hanging = 0;
-	// calculate how many elements are non-overlapping in initial request
-	if (start_offset < start_element)
-	{
-		hanging = start_element - start_offset;
-	}
-
-	do
-	{
-		// if local completely fits inside calculate percentage, fill, and exit
-		if (hanging + remaining <= request->size)
-		{
-			request->internal_status[current_part] += (double)remaining / request->size;
-			return;
-		}
-		// calculate how much of the supplied fits in the first partition.
-		else
-		{
-			int overlap = request->size - hanging;
-			request->internal_status[current_part] += (double)(overlap) / request->size; // convert to avoid int math
-			remaining = remaining - overlap;
-		}
-
-		// move on to next partition.
-		current_part++;
-		if (current_part > end_part)
-			break;
-		hanging = 0;
-
-	} while (remaining > 0);
-}
-
-// Run simple boolean check
-// Pros: Simple concept.
-// Cons: Have to use nested for loop.
-void map_send_buffer_bool(int id, MPIX_Request *request)
-{
-	int start_part = id * request->local_size / request->size;
-	int end_part = ((id + 1) * request->local_size - 1) / request->size;
+	int start_part, end_part;
+	map_local_partition(id, request, &start_part, &end_part);
 
 	// for each internal request effected
-	for (int i = start_part; i <= end_part; i++)
+	for (int i = start_part; i < end_part; i++)
 	{
-		// calculate the external partitions needed.
-		int ex_start_part = i * request->size / request->local_size;
-		int ex_end_part = ((i + 1) * request->size - 1) / request->local_size;
-		bool ready = false;
-
-		for (int j = ex_start_part; j <= ex_end_part; j++)
-		{
-			if (request->local_status[j] == false)
-			{
-				ready = false;
-				break;
-			}
-			else
-			{
-				ready = true;
-			}
-		}
-
-		// if ready is true after loop set status as ready.
-		request->internal_status[i] = ready;
-	}
-}
-
-// Run simple boolean check
-// Pros: Simple concept.
-// Cons: Have to use nested for loop.
-void map_send_buffer_count(int id, MPIX_Request *request)
-{
-	// MPIPCL_DEBUG("AT MAP %d \n",request->internal_status[id]);
-	int start_part = id * request->local_size / request->size;
-	int end_part = ((id + 1) * request->local_size - 1) / request->size;
-
-	// MPIPCL_DEBUG("start %d end %d \n",start_part, end_part);
-
-	// for each internal request effected
-	for (int i = start_part; i <= end_part; i++)
-	{
-		// calculate the external partitions needed.
-		int ex_start_part = i * request->size / request->local_size;
-		int ex_end_part = ((i + 1) * request->size - 1) / request->local_size;
-		int threshold = ex_end_part - ex_start_part + 1;
-
+		// increase the number of "local" partitions ready
 		request->internal_status[i]++;
 
-		// if ready is true after loop set status as ready.
+		int threshold = request->local_parts / request->parts;
+		MPIPCL_DEBUG("Count: %d, Threshold: %d\n", request->internal_status[i], threshold);
+
+		// if the number of local partitions needed for one network partition are ready
 		if (request->internal_status[i] == threshold)
 		{
+			// start associated request
 			MPIPCL_DEBUG("Starting request %d %p \n", i, (void *) (&request->request[i]));
 			int ret_val = MPI_Start(&request->request[i]);
 			assert(MPI_SUCCESS == ret_val);
@@ -145,12 +69,12 @@ int map_recv_buffer(int id, MPIX_Request *request)
 		return 1;
 	}
 
-	int start = id * request->local_size / request->size;
-	int end = ((id + 1) * request->local_size - 1) / request->size;
+	int start, end;
+	map_local_partition(id, request, &start, &end);
 
 	// check status of dependent requests
 	int flag = 0;
-	int ret_val = MPI_Testall(end - start + 1, &request->request[start], &flag, MPI_STATUSES_IGNORE);
+	int ret_val = MPI_Testall(end - start, &request->request[start], &flag, MPI_STATUSES_IGNORE);
 	assert(MPI_SUCCESS == ret_val);
 
 	// if true store for future shortcut

--- a/src/pt2pt/setup.c
+++ b/src/pt2pt/setup.c
@@ -5,7 +5,7 @@
 // calls functions in sync.c
 
 // fill in default values and bundle message data
-void prep(void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int opp, int tag, MPI_Info info, MPI_Comm comm, MPIX_Request *request)
+void prep(void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int opp, int tag, MPI_Comm comm, MPIX_Request *request)
 {
   /* update partitioned request object with default values*/
   request->state = INACTIVE;

--- a/src/pt2pt/sync.c
+++ b/src/pt2pt/sync.c
@@ -54,6 +54,7 @@ void *threaded_sync_driver(void *args)
 	}
 	else if (request->side == SENDER && request->state == ACTIVE)
 	{
+		MPIPCL_DEBUG("%d THREAD IS STARTING SENDS:%d \n", request->side, request->size)
 		send_ready(request);
 	}
 	// once caught up, signal thread completion and return.


### PR DESCRIPTION
When the number of recv-side partitions is different from the number of actual partitions used (i.e. the number of send and receive requests underneath), `MPIX_Parrived` would incorrectly calculate which underlying requests it needed to check, often just checking the 0'th index. `MPIX_Wait` is unaffected by this bug since it always just uses the number of requests.

This PR fixes this bug by adding a new function to properly do the conversions from "user partition ID" to "network partition ID(s)". I also changed the send side to make use of this function. Lastly, I added a new test that can be used to verify `MPIX_Parrived` is working by using it to make progress; this test will never complete if `MPIX_Parrived` does not return `true` for all partitions. 

Indepth summary changes:
- `examples/Basic/CMakeLists.txt` - Added new test
- `examples/Basic/mpipcltest7.c` - The new test described above. Run instructions are included in the file. Requires 2 processes.
- `include/mpipcl.h` - Removed unused functions; Removed the `MPI_Info` variable from a helper function (it was not used)
- `src/pt2pt/mpipcl.c` - Removed unused `MPI_Info` object from `prep` function (can always be added back if needed)
- `src/pt2pt/send.c` - Bulk of changes; Added new helper function `map_local_partition` which maps user partition ID to network partition ID. Updated `general_send` to no longer just call another function (moved that function into `general_send`). Updated `general_send` and `map_recv_buff` to use new `map_local_partition` function. Removed unused "send mapping" functions.
- `src/pt2pt/setup.c` - Removed unused `MPI_Info` object from `prep` function (can always be added back if needed)
- `src/pt2pt/sync.c` - Added extra debug 