### PR TITLE
Partition mapping bug fixes and Thread safety fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required (VERSION 3.17 FATAL_ERROR)
 project(MPIPCL VERSION 1.4.0 LANGUAGES C)
 
 ##### Available options #####
-option(BUILD_STATIC_LIBS "Build MPIPCL static library." OFF)
 option(BUILD_SHARED_LIBS "Build MPIPCL shared library." ON)
 option(WITH_DEBUG "Turn debug statements on or off." OFF)
 option(BUILD_EXAMPLES "Turn on building of MPIPCL Examples." OFF)
@@ -27,9 +26,9 @@ endif()
 
 if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
 	# add additional debug flags for DEBUG
-	target_compile_options(mpipcl PRIVATE -Wall -Wextra -Wpedantic)
-	target_compile_options(mpipcl PRIVATE -Wno-unused-parameter)
-	target_compile_options(mpipcl PRIVATE -ggdb)
+	target_compile_options(MPIPCL PRIVATE -Wall -Wextra -Wpedantic)
+	target_compile_options(MPIPCL PRIVATE -Wno-unused-parameter)
+	target_compile_options(MPIPCL PRIVATE -ggdb)
 endif()
 
 if(CMAKE_BUILD_TYPE MATCHES "DEBUG" OR WITH_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(MPIPCL PROPERTIES LINKER_LANGUAGE C)
 set_target_properties(MPIPCL PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(MPIPCL PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 set_target_properties(MPIPCL PROPERTIES PUBLIC_HEADER include/mpipcl.h)
-set_target_properties(MPIPCL PROPERTIES C_STANDARD 99)
+set_target_properties(MPIPCL PROPERTIES C_STANDARD 11)
 
 # set compile options for project
 

--- a/examples/Basic/CMakeLists.txt
+++ b/examples/Basic/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(mpipcl_test_execs "")
+set(mpipcl_test_cxx_execs "")
 
 add_executable(MPIPCL_Test_1 mpipcltest1.c)
 list(APPEND mpipcl_test_execs MPIPCL_Test_1)
@@ -24,12 +25,30 @@ list(APPEND mpipcl_test_execs MPIPCL_Test_7)
 add_executable(MPIPCL_Test_8 mpipcltest8.c)
 list(APPEND mpipcl_test_execs MPIPCL_Test_8)
 
+# Turn on C++ for this test
+enable_language(CXX)
+# Re-find MPI because we need the MPI::MPI_CXX (linking) target
+# This not C++ MPI bindings, but the C++ flags to compile with MPIC++
+find_package(MPI REQUIRED)
+add_executable(MPIPCL_Test_9 mpipcltest9.cpp)
+list(APPEND mpipcl_test_cxx_execs MPIPCL_Test_9)
+
 foreach(exec_target ${mpipcl_test_execs})
 	if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
 		target_compile_options(${exec_target} PRIVATE -Wall -Wextra -Wpedantic)
 	endif()
 	target_include_directories(${exec_target} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 	target_link_libraries(${exec_target} PUBLIC MPI::MPI_C)
+    target_link_libraries(${exec_target} PUBLIC MPIPCL)
+	target_link_libraries(${exec_target} PUBLIC Threads::Threads)
+endforeach()
+
+foreach(exec_target ${mpipcl_test_cxx_execs})
+	if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
+		target_compile_options(${exec_target} PRIVATE -Wall -Wextra -Wpedantic)
+	endif()
+	target_include_directories(${exec_target} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+	target_link_libraries(${exec_target} PUBLIC MPI::MPI_CXX)
     target_link_libraries(${exec_target} PUBLIC MPIPCL)
 	target_link_libraries(${exec_target} PUBLIC Threads::Threads)
 endforeach()

--- a/examples/Basic/CMakeLists.txt
+++ b/examples/Basic/CMakeLists.txt
@@ -21,6 +21,9 @@ list(APPEND mpipcl_test_execs MPIPCL_Test_6)
 add_executable(MPIPCL_Test_7 mpipcltest7.c)
 list(APPEND mpipcl_test_execs MPIPCL_Test_7)
 
+add_executable(MPIPCL_Test_8 mpipcltest8.c)
+list(APPEND mpipcl_test_execs MPIPCL_Test_8)
+
 foreach(exec_target ${mpipcl_test_execs})
 	if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
 		target_compile_options(${exec_target} PRIVATE -Wall -Wextra -Wpedantic)

--- a/examples/Basic/mpipcltest8.c
+++ b/examples/Basic/mpipcltest8.c
@@ -1,16 +1,10 @@
-/* Sample program to test the partitioned communication API.
- * This version uses threads on the send-side only, but allows
- * users to change the behind the scenes mode of partition
- * negotiation.
- *
+/* Program that tests most of the MPIPCL APIs, using 
+ * the "HARD" mode. This the MPI INFO flag that tells
+ * MPIPCL to use a hard-coded number of partitions (the
+ * value in the corresponding INFO key).
+ * 
  * To run:
- *    mpirun -np 2 ./<test> <npartitions> <bufsize> <mode>
- *    WHERE <mode> = 0 MPI_INFO_NULL -- library default)
- *                   1 PMODE = SENDER -- sender's partitions
- *                   2 PMODE = RECEIVER -- receiver's partitions
- *                   3 PMODE = HARD  -- a specific number chosen,
- *                              controlled by "HARD_NUMBER" below
- *    NOTE: bufsize % npartitions == 0
+ *    mpirun -np 2 ./<test>
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/Basic/mpipcltest8.c
+++ b/examples/Basic/mpipcltest8.c
@@ -1,0 +1,132 @@
+/* Sample program to test the partitioned communication API.
+ * This version uses threads on the send-side only, but allows
+ * users to change the behind the scenes mode of partition
+ * negotiation.
+ *
+ * To run:
+ *    mpirun -np 2 ./<test> <npartitions> <bufsize> <mode>
+ *    WHERE <mode> = 0 MPI_INFO_NULL -- library default)
+ *                   1 PMODE = SENDER -- sender's partitions
+ *                   2 PMODE = RECEIVER -- receiver's partitions
+ *                   3 PMODE = HARD  -- a specific number chosen,
+ *                              controlled by "HARD_NUMBER" below
+ *    NOTE: bufsize % npartitions == 0
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <mpi.h>
+#include <omp.h>
+#include "mpipcl.h"
+
+static inline void exchange(int rank, int nparts, MPI_Info the_info)
+{
+    int i, j;
+    int tag = 0xbad;
+    MPIX_Request req;
+    MPI_Status status;
+
+    int bufsize = nparts*(nparts/2)*(nparts*2);
+    int count = bufsize / nparts;
+    double* buf = malloc(sizeof(double) * bufsize);
+
+    if (0 == rank)
+    { /* sender */
+        MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD, the_info, &req);
+        MPIX_Start(&req);
+
+#pragma omp parallel for private(j) shared(buf, req) num_threads(nparts)
+        for (i = 0; i < nparts; i++)
+        {
+            /* initialize part of buffer in each thread */
+            for (j = 0; j < count; j++)
+                buf[j + i * count] = j + i * count + 1.0;
+
+            /* indicate buffer is ready */
+            MPIX_Pready(i, &req);
+        }
+
+        MPIX_Wait(&req, &status);
+    }
+    else
+    { /* receiver */
+        MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD, the_info, &req);
+        MPIX_Start(&req);
+    
+        for(i = 0; i < nparts; i++)
+        {
+            int arrived = 0;
+            while(0 == arrived)
+            {
+                MPIX_Parrived(&req, i, &arrived);
+            }
+            printf("Done with partition %d\n", i);
+        }
+    
+        double sum = 0.0;
+        /* compute the sum of the values received */
+        for (i = 0, sum = 0.0; i < bufsize; i++)
+            sum += buf[i];
+        
+        MPIX_Wait(&req, &status);
+        printf("#partitions = %d bufsize = %d count = %d sum = %f\n",
+               nparts, bufsize, count, sum);
+    }
+    MPIX_Request_free(&req);
+    free(buf);
+}
+
+int main(int argc, char *argv[])
+{
+    int provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
+    assert(provided == MPI_THREAD_SERIALIZED);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if ((size != 2))
+    {
+        printf("comm size must be 2 \n");
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+
+    int string_size = 20;
+    char* HARD_NUMBER = malloc(sizeof(char)*string_size);
+    HARD_NUMBER[0] = '4';
+    HARD_NUMBER[1] = '\0';
+    int nparts = atoi(HARD_NUMBER);
+
+    MPI_Info the_info;
+    MPI_Info_create(&the_info);
+    MPI_Info_set(the_info, "PMODE", "HARD");
+    MPI_Info_set(the_info, "SET", HARD_NUMBER);
+
+    if(1 == rank)
+    {
+        printf("Testing partitions equal to \"HARD\" preset: %d\n", nparts);
+    }
+    exchange(rank, nparts, the_info);
+
+    nparts = nparts*2;
+    if(1 == rank)
+    {
+        printf("Testing partitions equal to 2x \"HARD\" preset: %d\n", nparts);
+    }
+    exchange(rank, nparts, the_info);
+
+    nparts = nparts/4;
+    if(1 == rank)
+    {
+        printf("Testing partitions equal to 1/2 \"HARD\" preset: %d\n", nparts);
+    }
+    exchange(rank, nparts, the_info);
+
+    MPI_Info_free(&the_info);
+
+    free(HARD_NUMBER);
+    MPI_Finalize();
+
+    return 0;
+}

--- a/examples/Basic/mpipcltest9.cpp
+++ b/examples/Basic/mpipcltest9.cpp
@@ -1,0 +1,120 @@
+/* C++ version of Test 8 to make sure compiling
+* and linking works correctly.
+* 
+* To run:
+*    mpirun -np 2 ./<test>
+*/
+
+#include <string>
+
+#include "mpi.h"
+#include "mpipcl.h"
+
+static inline void exchange(int rank, double* buf, int bufsize, int nparts, MPI_Info the_info)
+{
+    int i, j;
+    int tag = 0xbad;
+    MPIX_Request req;
+    MPI_Status status;
+
+    int count = bufsize / nparts;
+    if (0 == rank)
+    { /* sender */
+        MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD, the_info, &req);
+        MPIX_Start(&req);
+
+#pragma omp parallel for private(j) shared(buf, req) num_threads(nparts)
+        for (i = 0; i < nparts; i++)
+        {
+            /* initialize part of buffer in each thread */
+            for (j = 0; j < count; j++)
+                buf[j + i * count] = j + i * count + 1.0;
+
+            /* indicate buffer is ready */
+            MPIX_Pready(i, &req);
+        }
+
+        MPIX_Wait(&req, &status);
+    }
+    else
+    { /* receiver */
+        MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD, the_info, &req);
+        MPIX_Start(&req);
+    
+        for(i = 0; i < nparts; i++)
+        {
+            int arrived = 0;
+            while(0 == arrived)
+            {
+                MPIX_Parrived(&req, i, &arrived);
+            }
+            printf("Done with partition %d\n", i);
+        }
+    
+        double sum = 0.0;
+        /* compute the sum of the values received */
+        for (i = 0, sum = 0.0; i < bufsize; i++)
+            sum += buf[i];
+        
+        MPIX_Wait(&req, &status);
+        printf("#partitions = %d bufsize = %d count = %d sum = %f\n",
+               nparts, bufsize, count, sum);
+    }
+    MPIX_Request_free(&req);
+}
+
+int main(int argc, char *argv[])
+{
+    int provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
+    assert(provided == MPI_THREAD_SERIALIZED);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if ((size != 2))
+    {
+        printf("comm size must be 2 \n");
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+
+    int string_size = 20;
+    std::string HARD_NUMBER = "4";
+    int nparts = atoi(HARD_NUMBER.c_str());
+
+    int bufsize = nparts*(nparts/2)*(nparts*2);
+    double* buf = new double[bufsize];
+
+    MPI_Info the_info;
+    MPI_Info_create(&the_info);
+    MPI_Info_set(the_info, "PMODE", "HARD");
+    MPI_Info_set(the_info, "SET", HARD_NUMBER.c_str());
+
+    if(1 == rank)
+    {
+        printf("Testing partitions equal to \"HARD\" preset: %d\n", nparts);
+    }
+    exchange(rank, buf, bufsize, nparts, the_info);
+
+    nparts = nparts*2;
+    if(1 == rank)
+    {
+        printf("Testing partitions equal to 2x \"HARD\" preset: %d\n", nparts);
+    }
+    exchange(rank, buf, bufsize, nparts, the_info);
+
+    nparts = nparts/4;
+    if(1 == rank)
+    {
+        printf("Testing partitions equal to 1/2 \"HARD\" preset: %d\n", nparts);
+    }
+    exchange(rank, buf, bufsize, nparts, the_info);
+
+    MPI_Info_free(&the_info);
+
+    delete[] buf;
+    MPI_Finalize();
+
+    return 0;
+}

--- a/include/mpipcl.h
+++ b/include/mpipcl.h
@@ -14,6 +14,7 @@ extern "C"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdatomic.h>
 #include <assert.h>
 
 #define MPIPCL_TAG_LENGTH 20
@@ -64,7 +65,7 @@ typedef struct _mpipcl_request
   enum Activation state;
   enum P2P_Side side;
   bool *local_status;   // status array - true if external partition is ready
-  int *internal_status; // status array - true if internal partition is ready
+  atomic_int *internal_status; // status array - true if internal partition is ready
   bool *complete;       // status array - true if internal request has been started.
 
   int local_parts; // number of partitions visible externally

--- a/include/mpipcl.h
+++ b/include/mpipcl.h
@@ -65,7 +65,11 @@ typedef struct _mpipcl_request
   enum Activation state;
   enum P2P_Side side;
   bool *local_status;   // status array - true if external partition is ready
+  #ifdef __cplusplus
+  void* internal_status; // C++ can't use "atomic_int" from C, so let's just make it void *
+  #else
   atomic_int *internal_status; // status array - true if internal partition is ready
+  #endif
   bool *complete;       // status array - true if internal request has been started.
 
   int local_parts; // number of partitions visible externally

--- a/include/mpipcl.h
+++ b/include/mpipcl.h
@@ -14,7 +14,9 @@ extern "C"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef __cplusplus
 #include <stdatomic.h>
+#endif
 #include <assert.h>
 
 #define MPIPCL_TAG_LENGTH 20

--- a/src/bindings/mpipcl.c
+++ b/src/bindings/mpipcl.c
@@ -92,13 +92,7 @@ int MPIPCL(_Parrived)(MPIPCL_REQUEST *request, int partition, int *flag)
     return MPI_SUCCESS;
   }
 
-  // if 1 to 1 map use shortcut
-  if (request->local_parts == request->parts)
-  {
-    return MPI_Test(&request->request[partition], flag, MPI_STATUS_IGNORE);
-  }
-
-  // else use mapping function.
+  // else use mapping function to check status
   *flag = map_recv_buffer(partition, request);
 
   return MPI_SUCCESS;

--- a/src/bindings/mpipcl.c
+++ b/src/bindings/mpipcl.c
@@ -82,11 +82,11 @@ int MPIPCL(_Parrived)(MPIPCL_REQUEST *request, int partition, int *flag)
   assert(request->side != SENDER);
 
   pthread_mutex_lock(&request->lock);
-  int status = request->threaded;
+  enum Thread_Status status = request->threaded;
   pthread_mutex_unlock(&request->lock);
 
   // if not synced - return early;
-  if (status == 0)
+  if (status == RUNNING)
   {
     *flag = 0;
     return MPI_SUCCESS;

--- a/src/pt2pt/setup.c
+++ b/src/pt2pt/setup.c
@@ -125,7 +125,7 @@ void internal_setup(MPIPCL_REQUEST *request)
   assert(MPI_SUCCESS == ret_val);
 
   // create partition status arrays.
-  request->internal_status = (int *)malloc(sizeof(int) * request->parts); // true if ready to send or received
+  request->internal_status = (atomic_int *)malloc(sizeof(atomic_int) * request->parts); // true if ready to send or received
   request->complete = (bool *)malloc(sizeof(bool) * request->parts);      // internal request has been started
 
   // for each allocated partition create a request based on side.
@@ -150,7 +150,8 @@ void internal_setup(MPIPCL_REQUEST *request)
                   (void *)&request->request[i]);
     }
 
-    request->internal_status[i] = 0;
+    // Since they're atomic, might as well do the atomic init call
+    atomic_init(&request->internal_status[i], 0);
     request->complete[i] = 0;
   }
 }


### PR DESCRIPTION
This has two main bug fixes:

1. Bugs related to how partitions are mapped between the user and the underlying MPI Requests. 
2. Fix for a race-condition in Pready (specifically inside `general_send`) by using an atomic variable for a counter that was being used

I added a new test (`mpipcltest8.c`) that tests the three different cases when using HARD mode (user partitions =;>;< network partitions). **Edit:** I added a second test (`mpipcltest9.cpp`) to ensure that C++ programs can use MPIPCL. This included tweaking the atomics code since C++ can't use C atomic types, and adding cmake code to get C++ enabled in the project

I also fixed some CMake typos and removed a useless line of code (`BUILD_STATIC_LIBRARY` is not a real cmake option)