### PR TITLE
Remove MPIX namespace in favor of MPIP namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,6 @@ option(BUILD_SHARED_LIBS "Build MPIPCL shared library." ON)
 option(WITH_DEBUG "Turn debug statements on or off." OFF)
 option(BUILD_EXAMPLES "Turn on building of MPIPCL Examples." OFF)
 cmake_dependent_option(EXAMPLES_TO_BIN "Create examples in <install>/bin. requires BUILD_EXAMPLES" OFF "BUILD_EXAMPLES" OFF)
-option(UNIQUE_NAMES "Changes the types and names of functions to MPIP instead of MPIX." OFF)
-
-## Check for incompatible options
-if(UNIQUE_NAMES AND BUILD_EXAMPLES)
-	message( FATAL_ERROR "No examples currently exist using the MPIP version of the API")
-endif()
 
 ##### Create main project target: MPIPCL #####
 add_library(MPIPCL "")
@@ -48,12 +42,6 @@ endif()
 if(WITH_DEBUG)
 	message(STATUS "Enabling debugging print outs")
 	add_definitions(-DWITH_DEBUG)
-endif()
-
-if(UNIQUE_NAMES)
-	message(STATUS "Using MPIP instead of MPIX for APIs")
-	# PUBLIC target for both this library and anyone who uses it
-	target_compile_definitions (MPIPCL PUBLIC MPIPCL_UNIQUE_NAMES=1 )
 endif()
 
 # Find extra libraries to link to

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Library implementation of MPI-4 Partitioned Communication (currently using persi
 
 This is a component of the MPI-Advance Project!
 
-The API provided by this project can be found in `mpipcl.h` in `/include/`. The source code is in the `/src/pt2pt` folder. The current version of our library creates an individual MPI Request for each partition, that is stored in the `MPIX_Request` object. These partition requests are launched with the respective calls to `MPI_PREADY` (or its variants) on the send-side. On the receive-side, the partition requests are launched when the `MPIX_Request` is started. The current version of the library also features a progress thread in the background to synchronize the number of internal partitions to use (useful for when the send-side and receive-side partitions don't match).
+The API provided by this project can be found in `mpipcl.h` in `/include/`. The source code is in the `/src/pt2pt` folder. The current version of our library creates an individual MPI Request for each partition, that is stored in the `MPIP_Request` object. These partition requests are launched with the respective calls to `MPI_PREADY` (or its variants) on the send-side. On the receive-side, the partition requests are launched when the `MPIP_Request` is started. The current version of the library also features a progress thread in the background to synchronize the number of internal partitions to use (useful for when the send-side and receive-side partitions don't match).
 
 The current implementation makes the following assumptions/shortcuts:
 1) The datatype is the same on both the sender and receiver processes
@@ -11,7 +11,7 @@ The current implementation makes the following assumptions/shortcuts:
 3) The amount of data described on the send-side must match the amount of data described on the receive-side, even if the partitions do not match
 4) The status object is not updated; it is ignored
 5) These API are invoked in MPI_THREAD_SERIALIZED mode (i.e., MPI_Init_thread with thread support for MPI_THREAD_SERIALIZED is used instead of MPI_Init)
-6) A new MPI request object called MPIX_Request is used to support partitioned communication
+6) A new MPI request object called MPIP_Request is used to support partitioned communication
 
 
 ## Building
@@ -31,6 +31,6 @@ By default cmake creates a shared library in the build folder, to instead create
 There are six examples provided by this library (found in the `examples/Basic` folder) Each example has the specific execution instructions at the top, but most follow this pattern:
 `mpirun -np <num_processes> ./<test_executable> <npartitions> <bufsize>`
 
-The first, second, and sixth example programs require only two processes, while the third, fourth, and fifth example programs require five processes. Note that `bufsize % npartitions == 0` must be true for all examples and combinations of buffer sizes and number of partitions. The fifth test is testing all of the `MPIX_Wait\Test` functions and their variants.
+The first, second, and sixth example programs require only two processes, while the third, fourth, and fifth example programs require five processes. Note that `bufsize % npartitions == 0` must be true for all examples and combinations of buffer sizes and number of partitions. The fifth test is testing all of the `MPIP_Wait\Test` functions and their variants.
 
 If `-DBUILD_EXAMPLES=ON` is provided during the `cmake` command, the tests will also be built when building MPIPCL. 

--- a/examples/Basic/mpipcltest1.c
+++ b/examples/Basic/mpipcltest1.c
@@ -20,7 +20,7 @@ int main(int argc, char* argv[])
     int rank, size, nparts, bufsize, count, tag = 0xbad;
     int i, j, provided;
     double *buf, sum;
-    MPIX_Request req;
+    MPIP_Request req;
     MPI_Status status;
 
     MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
@@ -50,9 +50,9 @@ int main(int argc, char* argv[])
 
     if (rank == 0)
     { /* sender */
-        MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
+        MPIP_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
                         MPI_INFO_NULL, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
 #pragma omp parallel for private(j) shared(buf, req) num_threads(nparts)
         for (i = 0; i < nparts; i++)
@@ -62,17 +62,17 @@ int main(int argc, char* argv[])
                 buf[j + i * count] = j + i * count + 1.0;
 
             /* indicate buffer is ready */
-            MPIX_Pready(i, &req);
+            MPIP_Pready(i, &req);
         }
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
     }
     else
     { /* receiver */
-        MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
+        MPIP_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
                         MPI_INFO_NULL, &req);
-        MPIX_Start(&req);
-        MPIX_Wait(&req, &status);
+        MPIP_Start(&req);
+        MPIP_Wait(&req, &status);
 
         /* compute the sum of the values received */
         for (i = 0, sum = 0.0; i < bufsize; i++)
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
                bufsize, count, sum);
     }
 
-    MPIX_Request_free(&req);
+    MPIP_Request_free(&req);
     free(buf);
     MPI_Finalize();
 

--- a/examples/Basic/mpipcltest5.c
+++ b/examples/Basic/mpipcltest5.c
@@ -1,7 +1,7 @@
 /* Sample program to test the partitioned communication API.
 
- * This program tests MPIX_Waitsome and MPIX_Testsome
- * MPIX_Waitall functions.
+ * This program tests MPIP_Waitsome and MPIP_Testsome
+ * MPIP_Waitall functions.
  *
  * To compile:
  *    mpicc -O -Wall -fopenmp -o mpipcltest5 mpipcltest5.c mpipcl.c
@@ -23,7 +23,7 @@ int main(int argc, char* argv[])
     int rank, size, nparts, bufsize, count, rc = 0;
     int provided;
     double* buf;
-    MPIX_Request req[NUMREQ];
+    MPIP_Request req[NUMREQ];
 
     MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
     assert(provided == MPI_THREAD_SERIALIZED);
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
         /* make the requests */
         for (int i = 0; i < NUMREQ; i++)
         {
-            rc = MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, i,
+            rc = MPIP_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, i,
                                  MPI_COMM_WORLD, MPI_INFO_NULL, &req[i]);
             assert(rc == MPI_SUCCESS);
         }
@@ -73,19 +73,19 @@ int main(int argc, char* argv[])
         for (int j = 0; j < NUMREQ; j++)
         {
             /* start request */
-            rc = MPIX_Start(&req[j]);
+            rc = MPIP_Start(&req[j]);
             assert(rc == MPI_SUCCESS);
 
             /* indicate buffer is ready */
-            rc = MPIX_Pready_range(0, nparts - 1, &req[j]);
+            rc = MPIP_Pready_range(0, nparts - 1, &req[j]);
             assert(rc == MPI_SUCCESS);
 
             /* wait for first request to complete before starting next */
-            rc = MPIX_Wait(&req[j], MPI_STATUSES_IGNORE);
+            rc = MPIP_Wait(&req[j], MPI_STATUSES_IGNORE);
             assert(rc == MPI_SUCCESS);
 
             /* clean up */
-            rc = MPIX_Request_free(&req[j]);
+            rc = MPIP_Request_free(&req[j]);
             assert(rc == MPI_SUCCESS);
         }
     }
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
         /* make requests */
         for (int i = 0; i < NUMREQ; i++)
         {
-            rc = MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, i,
+            rc = MPIP_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, i,
                                  MPI_COMM_WORLD, MPI_INFO_NULL, &req[i]);
             assert(rc == MPI_SUCCESS);
         }
@@ -103,14 +103,14 @@ int main(int argc, char* argv[])
         /* start all but last request */
         for (int k = 0; k < NUMREQ - 1; k++)
         {
-            rc = MPIX_Start(&req[k]);
+            rc = MPIP_Start(&req[k]);
             assert(rc == MPI_SUCCESS);
         }
 
         /* wait for a request to complete */
         int indices[NUMREQ];
         int complete = -1;  // number of complete requests
-        rc = MPIX_Waitsome(NUMREQ, req, &complete, indices, MPI_STATUS_IGNORE);
+        rc = MPIP_Waitsome(NUMREQ, req, &complete, indices, MPI_STATUS_IGNORE);
         assert(rc == MPI_SUCCESS);
 
         printf("Wait completed: %d (count: %d) \n", indices[0], complete);
@@ -124,7 +124,7 @@ int main(int argc, char* argv[])
         /* Testsome -- see if incomplete request is returned (it shouldn't be)
          */
         complete = -1;
-        rc = MPIX_Testsome(NUMREQ, req, &complete, indices, MPI_STATUS_IGNORE);
+        rc = MPIP_Testsome(NUMREQ, req, &complete, indices, MPI_STATUS_IGNORE);
         assert(rc == MPI_SUCCESS);
 
         printf("Testsome complete count: %d \n", complete);
@@ -133,11 +133,11 @@ int main(int argc, char* argv[])
         printf("\n");
 
         /* start final request */
-        rc = MPIX_Start(&req[NUMREQ - 1]);
+        rc = MPIP_Start(&req[NUMREQ - 1]);
         assert(rc == MPI_SUCCESS);
 
         /* wait for second to complete */
-        rc = MPIX_Waitall(NUMREQ, req, MPI_STATUS_IGNORE);
+        rc = MPIP_Waitall(NUMREQ, req, MPI_STATUS_IGNORE);
         assert(rc == MPI_SUCCESS);
         printf("Second request complete\n");
 
@@ -148,7 +148,7 @@ int main(int argc, char* argv[])
 
         for (int j = 0; j < NUMREQ; j++)
         {
-            rc = MPIX_Request_free(&req[j]);
+            rc = MPIP_Request_free(&req[j]);
             assert(rc == MPI_SUCCESS);
         }
 

--- a/examples/Basic/mpipcltest6.c
+++ b/examples/Basic/mpipcltest6.c
@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
     int rank, size, nparts, mode, bufsize, count, tag = 0xbad;
     int i, j, provided;
     double *buf, sum;
-    MPIX_Request req;
+    MPIP_Request req;
     MPI_Status status;
 
     MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
@@ -85,9 +85,9 @@ int main(int argc, char* argv[])
 
     if (rank == 0)
     { /* sender */
-        MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
+        MPIP_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
                         the_info, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
 #pragma omp parallel for private(j) shared(buf, req) num_threads(nparts)
         for (i = 0; i < nparts; i++)
@@ -97,17 +97,17 @@ int main(int argc, char* argv[])
                 buf[j + i * count] = j + i * count + 1.0;
 
             /* indicate buffer is ready */
-            MPIX_Pready(i, &req);
+            MPIP_Pready(i, &req);
         }
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
     }
     else
     { /* receiver */
-        MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
+        MPIP_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
                         the_info, &req);
-        MPIX_Start(&req);
-        MPIX_Wait(&req, &status);
+        MPIP_Start(&req);
+        MPIP_Wait(&req, &status);
 
         /* compute the sum of the values received */
         for (i = 0, sum = 0.0; i < bufsize; i++)
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
 
     if (mode != 0)
         MPI_Info_free(&the_info);
-    MPIX_Request_free(&req);
+    MPIP_Request_free(&req);
     free(buf);
     MPI_Finalize();
 

--- a/examples/Basic/mpipcltest7.c
+++ b/examples/Basic/mpipcltest7.c
@@ -22,7 +22,7 @@ int main(int argc, char* argv[])
     int rank, size, nparts, bufsize, count, tag = 0xbad;
     int i, j, provided;
     double *buf, sum;
-    MPIX_Request req;
+    MPIP_Request req;
     MPI_Status status;
 
     MPI_Init_thread(&argc, &argv, MPI_THREAD_SERIALIZED, &provided);
@@ -58,9 +58,9 @@ int main(int argc, char* argv[])
 
     if (rank == 0)
     { /* sender */
-        MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
+        MPIP_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
                         MPI_INFO_NULL, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
         for (i = 0; i < nparts; i++)
         {
@@ -69,30 +69,30 @@ int main(int argc, char* argv[])
                 buf[j + i * count] = j + i * count + 1.0;
 
             /* indicate buffer is ready */
-            MPIX_Pready(i, &req);
+            MPIP_Pready(i, &req);
         }
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
     }
     else
     { /* receiver */
         nparts *= 2;
         count = count / 2;
-        MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
+        MPIP_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
                         MPI_INFO_NULL, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
         for (i = 0; i < nparts; i++)
         {
             int done = 0;
             while (!done)
             {
-                MPIX_Parrived(&req, i, &done);
+                MPIP_Parrived(&req, i, &done);
             }
             printf("Done with partition %d\n", i);
         }
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
 
         /* compute the sum of the values received */
         for (i = 0, sum = 0.0; i < bufsize; i++)
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
                bufsize, count, sum);
     }
 
-    MPIX_Request_free(&req);
+    MPIP_Request_free(&req);
     free(buf);
     MPI_Finalize();
 

--- a/examples/Basic/mpipcltest8.c
+++ b/examples/Basic/mpipcltest8.c
@@ -19,15 +19,15 @@ static inline void exchange(int rank, double* buf, int bufsize, int nparts,
 {
     int i, j;
     int tag = 0xbad;
-    MPIX_Request req;
+    MPIP_Request req;
     MPI_Status status;
 
     int count = bufsize / nparts;
     if (0 == rank)
     { /* sender */
-        MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
+        MPIP_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
                         the_info, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
 #pragma omp parallel for private(j) shared(buf, req) num_threads(nparts)
         for (i = 0; i < nparts; i++)
@@ -37,23 +37,23 @@ static inline void exchange(int rank, double* buf, int bufsize, int nparts,
                 buf[j + i * count] = j + i * count + 1.0;
 
             /* indicate buffer is ready */
-            MPIX_Pready(i, &req);
+            MPIP_Pready(i, &req);
         }
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
     }
     else
     { /* receiver */
-        MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
+        MPIP_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
                         the_info, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
         for (i = 0; i < nparts; i++)
         {
             int arrived = 0;
             while (0 == arrived)
             {
-                MPIX_Parrived(&req, i, &arrived);
+                MPIP_Parrived(&req, i, &arrived);
             }
             printf("Done with partition %d\n", i);
         }
@@ -63,11 +63,11 @@ static inline void exchange(int rank, double* buf, int bufsize, int nparts,
         for (i = 0, sum = 0.0; i < bufsize; i++)
             sum += buf[i];
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
         printf("#partitions = %d bufsize = %d count = %d sum = %f\n", nparts,
                bufsize, count, sum);
     }
-    MPIX_Request_free(&req);
+    MPIP_Request_free(&req);
 }
 
 int main(int argc, char* argv[])

--- a/examples/Basic/mpipcltest9.cpp
+++ b/examples/Basic/mpipcltest9.cpp
@@ -15,15 +15,15 @@ static inline void exchange(int rank, double* buf, int bufsize, int nparts,
 {
     int i, j;
     int tag = 0xbad;
-    MPIX_Request req;
+    MPIP_Request req;
     MPI_Status status;
 
     int count = bufsize / nparts;
     if (0 == rank)
     { /* sender */
-        MPIX_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
+        MPIP_Psend_init(buf, nparts, count, MPI_DOUBLE, 1, tag, MPI_COMM_WORLD,
                         the_info, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
 #pragma omp parallel for private(j) shared(buf, req) num_threads(nparts)
         for (i = 0; i < nparts; i++)
@@ -33,23 +33,23 @@ static inline void exchange(int rank, double* buf, int bufsize, int nparts,
                 buf[j + i * count] = j + i * count + 1.0;
 
             /* indicate buffer is ready */
-            MPIX_Pready(i, &req);
+            MPIP_Pready(i, &req);
         }
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
     }
     else
     { /* receiver */
-        MPIX_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
+        MPIP_Precv_init(buf, nparts, count, MPI_DOUBLE, 0, tag, MPI_COMM_WORLD,
                         the_info, &req);
-        MPIX_Start(&req);
+        MPIP_Start(&req);
 
         for (i = 0; i < nparts; i++)
         {
             int arrived = 0;
             while (0 == arrived)
             {
-                MPIX_Parrived(&req, i, &arrived);
+                MPIP_Parrived(&req, i, &arrived);
             }
             printf("Done with partition %d\n", i);
         }
@@ -59,11 +59,11 @@ static inline void exchange(int rank, double* buf, int bufsize, int nparts,
         for (i = 0, sum = 0.0; i < bufsize; i++)
             sum += buf[i];
 
-        MPIX_Wait(&req, &status);
+        MPIP_Wait(&req, &status);
         printf("#partitions = %d bufsize = %d count = %d sum = %f\n", nparts,
                bufsize, count, sum);
     }
-    MPIX_Request_free(&req);
+    MPIP_Request_free(&req);
 }
 
 int main(int argc, char* argv[])

--- a/include/mpipcl.h
+++ b/include/mpipcl.h
@@ -19,19 +19,6 @@ extern "C" {
 
 #define MPIPCL_TAG_LENGTH 20
 
-#ifndef MPIPCL_UNIQUE_NAMES
-#define MPIPCL_REQUEST MPIX_Request
-#define MPIPCL_NAMESPACE MPIX
-#else
-#define MPIPCL_REQUEST MPIP_Request
-#define MPIPCL_NAMESPACE MPIP
-#endif
-
-// Determines name of function based on "MPIPCL_UNIQUE_NAMES"
-#define CONCAT(namespace, name) namespace##name
-#define EXPAND(namespace, name) CONCAT(namespace, name)
-#define MPIPCL(name) EXPAND(MPIPCL_NAMESPACE, name)
-
 // structure to hold message settings if threaded sync is necessary
 typedef struct _meta_
 {
@@ -42,7 +29,7 @@ typedef struct _meta_
     MPI_Datatype type;
 } meta;
 
-// enums for mpix request attributes
+// enums for MPIP request attributes
 enum P2P_Side
 {
     SENDER   = 0,
@@ -60,7 +47,7 @@ enum Thread_Status
     FINISHED = 1
 };
 
-typedef struct _mpipcl_request
+typedef struct _MPIP_Request
 {
     enum Activation state;
     enum P2P_Side side;
@@ -90,71 +77,71 @@ typedef struct _mpipcl_request
     pthread_mutex_t lock;
     enum Thread_Status
         threaded;  // status of sync thread "-1"-no_thread, 0-exist, 1-finished
-} MPIPCL_REQUEST;
+} MPIP_Request;
 
 //----------------------------------------------------------------------------------------------
 
-int MPIPCL(_Psend_init)(void* buf, int partitions, MPI_Count count,
+int MPIP_Psend_init(void* buf, int partitions, MPI_Count count,
                         MPI_Datatype datatype, int dest, int tag, MPI_Comm comm,
-                        MPI_Info info, MPIPCL_REQUEST* request);
+                        MPI_Info info, MPIP_Request* request);
 
-int MPIPCL(_Precv_init)(void* buf, int partitions, MPI_Count count,
+int MPIP_Precv_init(void* buf, int partitions, MPI_Count count,
                         MPI_Datatype datatype, int dest, int tag, MPI_Comm comm,
-                        MPI_Info info, MPIPCL_REQUEST* request);
+                        MPI_Info info, MPIP_Request* request);
 
-int MPIPCL(_Pready)(int partition, MPIPCL_REQUEST* request);
+int MPIP_Pready(int partition, MPIP_Request* request);
 
-int MPIPCL(_Pready_range)(int partition_low, int partition_high,
-                          MPIPCL_REQUEST* request);
+int MPIP_Pready_range(int partition_low, int partition_high,
+                          MPIP_Request* request);
 
-int MPIPCL(_Pready_list)(int length, int array_of_partitions[],
-                         MPIPCL_REQUEST* request);
+int MPIP_Pready_list(int length, int array_of_partitions[],
+                         MPIP_Request* request);
 
-int MPIPCL(_Parrived)(MPIPCL_REQUEST* request, int partition, int* flag);
+int MPIP_Parrived(MPIP_Request* request, int partition, int* flag);
 
-int MPIPCL(_Start)(MPIPCL_REQUEST* request);
-int MPIPCL(_Startall)(int count, MPIPCL_REQUEST array_of_requests[]);
+int MPIP_Start(MPIP_Request* request);
+int MPIP_Startall(int count, MPIP_Request array_of_requests[]);
 
-int MPIPCL(_Wait)(MPIPCL_REQUEST* request, MPI_Status* status);
-int MPIPCL(_Waitall)(int count, MPIPCL_REQUEST array_of_requests[],
+int MPIP_Wait(MPIP_Request* request, MPI_Status* status);
+int MPIP_Waitall(int count, MPIP_Request array_of_requests[],
                      MPI_Status array_of_statuses[]);
-int MPIPCL(_Waitany)(int count, MPIPCL_REQUEST array_of_requests[], int* index,
+int MPIP_Waitany(int count, MPIP_Request array_of_requests[], int* index,
                      MPI_Status* status);
-int MPIPCL(_Waitsome)(int incount, MPIPCL_REQUEST array_of_requests[],
+int MPIP_Waitsome(int incount, MPIP_Request array_of_requests[],
                       int* outcount, int array_of_indices[],
                       MPI_Status array_of_statuses[]);
 
-int MPIPCL(_Test)(MPIPCL_REQUEST* request, int* flag, MPI_Status* status);
-int MPIPCL(_Testall)(int count, MPIPCL_REQUEST array_of_requests[], int* flag,
+int MPIP_Test(MPIP_Request* request, int* flag, MPI_Status* status);
+int MPIP_Testall(int count, MPIP_Request array_of_requests[], int* flag,
                      MPI_Status array_of_statuses[]);
-int MPIPCL(_Testany)(int count, MPIPCL_REQUEST array_of_requests[], int* index,
+int MPIP_Testany(int count, MPIP_Request array_of_requests[], int* index,
                      int* flag, MPI_Status* status);
-int MPIPCL(_Testsome)(int incount, MPIPCL_REQUEST array_of_requests[],
+int MPIP_Testsome(int incount, MPIP_Request array_of_requests[],
                       int* outcount, int array_of_indices[],
                       MPI_Status array_of_statuses[]);
 
-int MPIPCL(_Request_free)(MPIPCL_REQUEST* request);
+int MPIP_Request_free(MPIP_Request* request);
 
 // functions current defined outside of mpipcl
 // setup.c
 void prep(void* buf, int partitions, MPI_Count count, MPI_Datatype datatype,
-          int opp, int tag, MPI_Comm comm, MPIPCL_REQUEST* request);
-int sync_driver(MPI_Info info, MPIPCL_REQUEST* request);
-void internal_setup(MPIPCL_REQUEST* request);
-void reset_status(MPIPCL_REQUEST* request);
+          int opp, int tag, MPI_Comm comm, MPIP_Request* request);
+int sync_driver(MPI_Info info, MPIP_Request* request);
+void internal_setup(MPIP_Request* request);
+void reset_status(MPIP_Request* request);
 
 // sync.c
-void sync_hard(int option, MPIPCL_REQUEST* request);
-void sync_side(enum P2P_Side driver, MPIPCL_REQUEST* request);
+void sync_hard(int option, MPIP_Request* request);
+void sync_side(enum P2P_Side driver, MPIP_Request* request);
 void* threaded_sync_driver(void* args);
 
 // send.c
 // send functions
-void send_ready(MPIPCL_REQUEST* request);
-void general_send(int id, MPIPCL_REQUEST* request);
+void send_ready(MPIP_Request* request);
+void general_send(int id, MPIP_Request* request);
 
 // remap functions
-int map_recv_buffer(int id, MPIPCL_REQUEST* request);
+int map_recv_buffer(int id, MPIP_Request* request);
 
 // debug functions
 #if defined(WITH_DEBUG)

--- a/src/pt2pt/send.c
+++ b/src/pt2pt/send.c
@@ -4,7 +4,7 @@
 
 // call send function on all marked partitions
 // catchup function for sync thread.
-void send_ready(MPIPCL_REQUEST* request)
+void send_ready(MPIP_Request* request)
 {
     // call send on each currently marked partition
     for (int i = 0; i < request->local_parts; i++)
@@ -17,7 +17,7 @@ void send_ready(MPIPCL_REQUEST* request)
 }
 
 static inline void map_local_to_network_partitions(int user_partition_id,
-                                                   MPIPCL_REQUEST* request,
+                                                   MPIP_Request* request,
                                                    int* start, int* end)
 {
     int user_partitions    = request->local_parts;
@@ -37,7 +37,7 @@ static inline void map_local_to_network_partitions(int user_partition_id,
 }
 
 // given partition id, send now ready internal requests.
-void general_send(int id, MPIPCL_REQUEST* request)
+void general_send(int id, MPIP_Request* request)
 {
     int start_part = 0;
     int end_part   = 0;
@@ -85,7 +85,7 @@ void general_send(int id, MPIPCL_REQUEST* request)
 // maps recv_buffer offset -- parried related.
 // returns 1 if ready, 0 otherwise.
 // all results from race condition identical, no lock needed.
-int map_recv_buffer(int id, MPIPCL_REQUEST* request)
+int map_recv_buffer(int id, MPIP_Request* request)
 {
     if (request->local_status[id] == true)
     {

--- a/src/pt2pt/setup.c
+++ b/src/pt2pt/setup.c
@@ -6,7 +6,7 @@
 
 // fill in default values and bundle message data
 void prep(void* buf, int partitions, MPI_Count count, MPI_Datatype datatype,
-          int opp, int tag, MPI_Comm comm, MPIPCL_REQUEST* request)
+          int opp, int tag, MPI_Comm comm, MPIP_Request* request)
 {
     /* update partitioned request object with default values*/
     request->state       = INACTIVE;
@@ -41,7 +41,7 @@ void prep(void* buf, int partitions, MPI_Count count, MPI_Datatype datatype,
 }
 
 // decode info object and call appropriate sync operation
-int sync_driver(MPI_Info info, MPIPCL_REQUEST* request)
+int sync_driver(MPI_Info info, MPIP_Request* request)
 {
     int flag;
     char mode[10];
@@ -117,7 +117,7 @@ int sync_driver(MPI_Info info, MPIPCL_REQUEST* request)
 // setup internal requests and status control variables for request -- always
 // needed. Assumes that sync has been run and request->parts & request->size has
 // been set.
-void internal_setup(MPIPCL_REQUEST* request)
+void internal_setup(MPIP_Request* request)
 {
     MPI_Aint lb, extent, offset;
     meta* mes = request->comm_data;
@@ -170,7 +170,7 @@ void internal_setup(MPIPCL_REQUEST* request)
 }
 
 // initialize progress status in request.
-void reset_status(MPIPCL_REQUEST* request)
+void reset_status(MPIP_Request* request)
 {
     // reset internal flags
     for (int i = 0; i < request->parts; i++)

--- a/src/pt2pt/sync.c
+++ b/src/pt2pt/sync.c
@@ -1,14 +1,14 @@
 #include "mpipcl.h"
 // implemented synchronization modes
 
-void sync_hard(int option, MPIPCL_REQUEST* request)
+void sync_hard(int option, MPIP_Request* request)
 {
     request->parts = option;
     request->size  = request->local_parts * request->local_size / option;
 }
 
 // Send/Receive sync data to/from partner thread
-void sync_side(enum P2P_Side driver, MPIPCL_REQUEST* request)
+void sync_side(enum P2P_Side driver, MPIP_Request* request)
 {
     // extract comm data from meta block
     int partner   = request->comm_data->partner;
@@ -39,7 +39,7 @@ void sync_side(enum P2P_Side driver, MPIPCL_REQUEST* request)
 void* threaded_sync_driver(void* args)
 {
     // Convert blob to correct type
-    MPIPCL_REQUEST* request = (MPIPCL_REQUEST*)args;
+    MPIP_Request* request = (MPIP_Request*)args;
 
     sync_side(!request->side, request);
     internal_setup(request);


### PR DESCRIPTION
- Removed ability do MPIX namespace; all functions are now always in MPIP (in accordance with our design for the 1.0 release of MPI Advance). 
- Removed the related CMake options
- Updated all of the basic examples