### PR TITLE
Remove unused "complete" variable from the MPIP_Request variable

### DIFF
--- a/include/mpipcl.h
+++ b/include/mpipcl.h
@@ -116,12 +116,6 @@ typedef struct _MPIP_Request
     atomic_int* internal_status;
 #endif
 
-    /** @brief Booleans representing the completion status of the overall request
-     * @details
-     * TO BE REMOVED
-     */
-    bool* complete;
-
     /** @brief Number of partitions visible externally
      * @details
      * This value is equal to the partitions number provided by the user in
@@ -442,8 +436,6 @@ int sync_driver(MPI_Info info, MPIP_Request* request);
  * number of messages and partitions are determined:
  * - MPIP_Request::request
  * - MPIP_Request::internal_status
- * - MPIP_Request::complete
- * @todo REMOVE COMPLETE
  *
  * @param [in, out] request Pointer to the @ref MPIP_Request being initialized
  */
@@ -454,8 +446,6 @@ void internal_setup(MPIP_Request* request);
  * Reset the following members to zero in preparation of starting the request again:
  * - MPIP_Request::internal_status (internal partitions)
  * - MPIP_Request::local_status (external partitions)
- * - MPIP_Request::complete
- * @todo REMOVE COMPLETE
  *
  * @param [in, out] request Pointer to the @ref MPIP_Request being reset
  */

--- a/src/bindings/mpipcl.c
+++ b/src/bindings/mpipcl.c
@@ -365,7 +365,6 @@ int MPIP_Request_free(MPIP_Request* request)
     // free internal request status buffers
     free(request->local_status);
     free(request->internal_status);
-    free(request->complete);
 
     // free comm_data -- //could this be freed earlier?
     free(request->comm_data);

--- a/src/pt2pt/setup.c
+++ b/src/pt2pt/setup.c
@@ -145,9 +145,6 @@ void internal_setup(MPIP_Request* request)
     request->internal_status = (atomic_int*)malloc(sizeof(atomic_int) * request->parts);
     assert(request->internal_status != NULL);
 
-    request->complete = (bool*)malloc(sizeof(bool) * request->parts);
-    assert(request->complete != NULL);
-
     // for each allocated partition create a request based on side.
     for (int i = 0; i < request->parts; i++)
     {
@@ -184,7 +181,6 @@ void internal_setup(MPIP_Request* request)
 
         // Since they're atomic, might as well do the atomic init call
         atomic_init(&request->internal_status[i], 0);
-        request->complete[i] = 0;
     }
 }
 
@@ -195,7 +191,6 @@ void reset_status(MPIP_Request* request)
     for (int i = 0; i < request->parts; i++)
     {
         request->internal_status[i] = 0;
-        request->complete[i]        = 0;
     }
     for (int i = 0; i < request->local_parts; i++)
     {


### PR DESCRIPTION
Removed all code and documentation related to variable. Tested with example 9 and example 4.

Will close #18 