### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set_target_properties(MPIPCL PROPERTIES C_STANDARD 11)
 # Set default build type
 if(NOT CMAKE_BUILD_TYPE)
 	message(STATUS "No CMAKE_BUILD_TYPE specified, setting build type to RELEASE.")
-	set(CMAKE_BUILD_TYPE "RELEASE")
+	set(CMAKE_BUILD_TYPE RELEASE CACHE STRING "Build type for project." FORCE)
 endif()
 
 # Convert to lower case string to ignore case


### PR DESCRIPTION
Properly propagate default build type for anything that tries to use cmake package file. Without this, trying to find the mpipcl cmake module doesn't quite work when the user doesn't specify any build type (see closed PR in locality_aware as well)